### PR TITLE
add missing imports

### DIFF
--- a/src/CacheInterface.php
+++ b/src/CacheInterface.php
@@ -2,6 +2,9 @@
 
 namespace Psr\SimpleCache;
 
+use DateInterval;
+use Traversable;
+
 interface CacheInterface
 {
     /**


### PR DESCRIPTION
add imports for `DateInterval` and `Traversable` for proper static inspections (phan, Storm, code-sniffer, etc.)