### PR TITLE
Corrected type hints

### DIFF
--- a/src/CacheInterface.php
+++ b/src/CacheInterface.php
@@ -2,6 +2,9 @@
 
 namespace Psr\SimpleCache;
 
+use DateInterval;
+use Traversable;
+
 interface CacheInterface
 {
     /**

--- a/src/CacheInterface.php
+++ b/src/CacheInterface.php
@@ -58,10 +58,10 @@ interface CacheInterface
     /**
      * Obtains multiple cache items by their unique keys.
      *
-     * @param iterable $keys    A list of keys that can obtained in a single operation.
-     * @param mixed    $default Default value to return for keys that do not exist.
+     * @param array|Traversable $keys    A list of keys that can obtained in a single operation.
+     * @param mixed             $default Default value to return for keys that do not exist.
      *
-     * @return iterable A list of key => value pairs. Cache keys that do not exist or are stale will have $default as value.
+     * @return array|Traversable A list of key => value pairs. Cache keys that do not exist or are stale will have $default as value.
      *
      * @throws \Psr\SimpleCache\InvalidArgumentException
      *   MUST be thrown if $keys is neither an array nor a Traversable,
@@ -72,7 +72,7 @@ interface CacheInterface
     /**
      * Persists a set of key => value pairs in the cache, with an optional TTL.
      *
-     * @param iterable              $values A list of key => value pairs for a multiple-set operation.
+     * @param array|Traversable     $values A list of key => value pairs for a multiple-set operation.
      * @param null|int|DateInterval $ttl    Optional. The TTL value of this item. If no value is sent and
      *                                      the driver supports TTL then the library may set a default value
      *                                      for it or let the driver take care of that.
@@ -88,7 +88,7 @@ interface CacheInterface
     /**
      * Deletes multiple cache items in a single operation.
      *
-     * @param iterable $keys A list of string-based keys to be deleted.
+     * @param array|Traversable $keys A list of string-based keys to be deleted.
      *
      * @return bool True if the items were successfully removed. False if there was an error.
      *


### PR DESCRIPTION
Per [this thread](https://github.com/php-fig/simple-cache/commit/c671bf12e2e3d06e8af28421177b15b9f29d55e0), I understand that tool support is not a concern or priority for the FIG, so I don't expect this PR will be merged - a replacement package with corrected type-hints has been published and can be installed as `mindplay/simple-cache` now.
