### PR TITLE
Corrected type hints

### DIFF
--- a/src/CacheInterface.php
+++ b/src/CacheInterface.php
@@ -22,7 +22,7 @@ interface CacheInterface
      *
      * @param string                $key   The key of the item to store.
      * @param mixed                 $value The value of the item to store, must be serializable.
-     * @param null|int|DateInterval $ttl   Optional. The TTL value of this item. If no value is sent and
+     * @param null|int|\DateInterval $ttl   Optional. The TTL value of this item. If no value is sent and
      *                                     the driver supports TTL then the library may set a default value
      *                                     for it or let the driver take care of that.
      *
@@ -70,7 +70,7 @@ interface CacheInterface
      * Persists a set of key => value pairs in the cache, with an optional TTL.
      *
      * @param iterable              $values A list of key => value pairs for a multiple-set operation.
-     * @param null|int|DateInterval $ttl    Optional. The TTL value of this item. If no value is sent and
+     * @param null|int|\DateInterval $ttl    Optional. The TTL value of this item. If no value is sent and
      *                                      the driver supports TTL then the library may set a default value
      *                                      for it or let the driver take care of that.
      *


### PR DESCRIPTION
IDE tries to find non existing class `\Psr\SimpleCache\DateInterval`, hints in doc comment should unambiguously points to specific class (like [here](https://github.com/php-fig/simple-cache/blob/c671bf12e2e3d06e8af28421177b15b9f29d55e0/src/CacheInterface.php#L15)).