### PR TITLE
Fix type-hint for `DateInterval` in PHPDoc

### DIFF
--- a/src/CacheInterface.php
+++ b/src/CacheInterface.php
@@ -2,6 +2,15 @@
 
 namespace Psr\SimpleCache;
 
+/**
+ * Describes a cache items collection.
+ *
+ * This interface defines the most basic operations on a collection of cache-entries, which entails basic reading,
+ * writing and deleting individual cache items.
+ *
+ * See https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-16-simple-cache.md
+ * for the full interface specification.
+ */
 interface CacheInterface
 {
     /**
@@ -22,7 +31,7 @@ interface CacheInterface
      *
      * @param string                $key   The key of the item to store.
      * @param mixed                 $value The value of the item to store, must be serializable.
-     * @param null|int|DateInterval $ttl   Optional. The TTL value of this item. If no value is sent and
+     * @param null|int|\DateInterval $ttl   Optional. The TTL value of this item. If no value is sent and
      *                                     the driver supports TTL then the library may set a default value
      *                                     for it or let the driver take care of that.
      *
@@ -70,7 +79,7 @@ interface CacheInterface
      * Persists a set of key => value pairs in the cache, with an optional TTL.
      *
      * @param iterable              $values A list of key => value pairs for a multiple-set operation.
-     * @param null|int|DateInterval $ttl    Optional. The TTL value of this item. If no value is sent and
+     * @param null|int|\DateInterval $ttl    Optional. The TTL value of this item. If no value is sent and
      *                                      the driver supports TTL then the library may set a default value
      *                                      for it or let the driver take care of that.
      *

--- a/src/CacheInterface.php
+++ b/src/CacheInterface.php
@@ -29,11 +29,11 @@ interface CacheInterface
     /**
      * Persists data in the cache, uniquely referenced by a key with an optional expiration TTL time.
      *
-     * @param string                $key   The key of the item to store.
-     * @param mixed                 $value The value of the item to store, must be serializable.
+     * @param string                 $key   The key of the item to store.
+     * @param mixed                  $value The value of the item to store, must be serializable.
      * @param null|int|\DateInterval $ttl   Optional. The TTL value of this item. If no value is sent and
-     *                                     the driver supports TTL then the library may set a default value
-     *                                     for it or let the driver take care of that.
+     *                                      the driver supports TTL then the library may set a default value
+     *                                      for it or let the driver take care of that.
      *
      * @return bool True on success and false on failure.
      *
@@ -78,10 +78,10 @@ interface CacheInterface
     /**
      * Persists a set of key => value pairs in the cache, with an optional TTL.
      *
-     * @param iterable              $values A list of key => value pairs for a multiple-set operation.
+     * @param iterable               $values A list of key => value pairs for a multiple-set operation.
      * @param null|int|\DateInterval $ttl    Optional. The TTL value of this item. If no value is sent and
-     *                                      the driver supports TTL then the library may set a default value
-     *                                      for it or let the driver take care of that.
+     *                                       the driver supports TTL then the library may set a default value
+     *                                       for it or let the driver take care of that.
      *
      * @return bool True on success and false on failure.
      *


### PR DESCRIPTION
This PR fixes type-hint for `DateInterval`, which should be marked as class from global namespace with leading backslash (`\`) otherwise IDE assumes it refers to `Psr\SimpleCache\DateInterval`, which does not exist.

In addition basic class PHPDoc for `CacheInterface` provided to be consistent with interface definitions from other PSRs.