### PR TITLE
Add PHP parameter types

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": ">=7.2.0"
+        "php": ">=8.0.0"
     },
     "autoload": {
         "psr-4": {
@@ -19,7 +19,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.1.x-dev"
+            "dev-master": "1.2.x-dev"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.0"
+        "php": ">=7.2.0"
     },
     "autoload": {
         "psr-4": {
@@ -19,7 +19,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.0.x-dev"
+            "dev-master": "1.1.x-dev"
         }
     }
 }

--- a/src/CacheInterface.php
+++ b/src/CacheInterface.php
@@ -15,7 +15,7 @@ interface CacheInterface
      * @throws \Psr\SimpleCache\InvalidArgumentException
      *   MUST be thrown if the $key string is not a legal value.
      */
-    public function get(string $key, $default = null);
+    public function get(string $key, mixed $default = null);
 
     /**
      * Persists data in the cache, uniquely referenced by a key with an optional expiration TTL time.
@@ -31,7 +31,7 @@ interface CacheInterface
      * @throws \Psr\SimpleCache\InvalidArgumentException
      *   MUST be thrown if the $key string is not a legal value.
      */
-    public function set(string $key, $value, $ttl = null);
+    public function set(string $key, mixed $value, null|int|\DateInterval $ttl = null);
 
     /**
      * Delete an item from the cache by its unique key.
@@ -64,7 +64,7 @@ interface CacheInterface
      *   MUST be thrown if $keys is neither an array nor a Traversable,
      *   or if any of the $keys are not a legal value.
      */
-    public function getMultiple(iterable $keys, $default = null);
+    public function getMultiple(iterable $keys, mixed $default = null);
 
     /**
      * Persists a set of key => value pairs in the cache, with an optional TTL.
@@ -80,7 +80,7 @@ interface CacheInterface
      *   MUST be thrown if $values is neither an array nor a Traversable,
      *   or if any of the $values are not a legal value.
      */
-    public function setMultiple(iterable $values, $ttl = null);
+    public function setMultiple(iterable $values, null|int|\DateInterval $ttl = null);
 
     /**
      * Deletes multiple cache items in a single operation.

--- a/src/CacheInterface.php
+++ b/src/CacheInterface.php
@@ -15,7 +15,7 @@ interface CacheInterface
      * @throws \Psr\SimpleCache\InvalidArgumentException
      *   MUST be thrown if the $key string is not a legal value.
      */
-    public function get($key, $default = null);
+    public function get(string $key, $default = null);
 
     /**
      * Persists data in the cache, uniquely referenced by a key with an optional expiration TTL time.
@@ -31,7 +31,7 @@ interface CacheInterface
      * @throws \Psr\SimpleCache\InvalidArgumentException
      *   MUST be thrown if the $key string is not a legal value.
      */
-    public function set($key, $value, $ttl = null);
+    public function set(string $key, $value, $ttl = null);
 
     /**
      * Delete an item from the cache by its unique key.
@@ -43,7 +43,7 @@ interface CacheInterface
      * @throws \Psr\SimpleCache\InvalidArgumentException
      *   MUST be thrown if the $key string is not a legal value.
      */
-    public function delete($key);
+    public function delete(string $key);
 
     /**
      * Wipes clean the entire cache's keys.
@@ -64,7 +64,7 @@ interface CacheInterface
      *   MUST be thrown if $keys is neither an array nor a Traversable,
      *   or if any of the $keys are not a legal value.
      */
-    public function getMultiple($keys, $default = null);
+    public function getMultiple(iterable $keys, $default = null);
 
     /**
      * Persists a set of key => value pairs in the cache, with an optional TTL.
@@ -80,7 +80,7 @@ interface CacheInterface
      *   MUST be thrown if $values is neither an array nor a Traversable,
      *   or if any of the $values are not a legal value.
      */
-    public function setMultiple($values, $ttl = null);
+    public function setMultiple(iterable $values, $ttl = null);
 
     /**
      * Deletes multiple cache items in a single operation.
@@ -93,7 +93,7 @@ interface CacheInterface
      *   MUST be thrown if $keys is neither an array nor a Traversable,
      *   or if any of the $keys are not a legal value.
      */
-    public function deleteMultiple($keys);
+    public function deleteMultiple(iterable $keys);
 
     /**
      * Determines whether an item is present in the cache.
@@ -110,5 +110,5 @@ interface CacheInterface
      * @throws \Psr\SimpleCache\InvalidArgumentException
      *   MUST be thrown if the $key string is not a legal value.
      */
-    public function has($key);
+    public function has(string $key);
 }


### PR DESCRIPTION
Included in this PR are two commits, proposing:

v1.1 for PHP 7.2+ with parameter types (PHP 7.2 the first version with parameter type widening to prevent bc breaks)
v1.2 for PHP 8 with union parameter types and mixed type