### PR TITLE
Introduce CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,28 @@
+# Changelog
+
+All notable changes to this project will be documented in this file, in reverse chronological order by release.
+
+## [3.0.0](https://github.com/php-fig/simple-cache/compare/2.0.0...3.0.0) - 2021-10-29
+
+### Changed
+
+- **BREAKING** All methods have return types
+
+## [2.0.0](https://github.com/php-fig/simple-cache/compare/1.0.1...2.0.0) - 2021-10-29
+
+### Changed
+
+- Adds parameter types
+- Makes `CacheException` extend `\Throwable`
+- Requires PHP 8
+
+
+## [1.0.1](https://github.com/php-fig/simple-cache/compare/1.0.0...1.0.1) - 2018-03-05
+
+### Fixed
+
+- Include slash at the beginning for DateInterval in typehint - michaelcullum
+
+## 1.0.0 - 2017-01-02
+
+Initial stable release; reflects accepted [PSR-16 specification](https://www.php-fig.org/psr/psr-16/)


### PR DESCRIPTION
I was looking at the dependency graph of some of my applications and I noticed I was mostly depending on `psr/simple-cache:^1.0`. I knew about the introduction of version 2.0.0 and 3.0.0 and of the rationale behind having a separate 2.0.0 and 3.0.0 branch. What I had forgotten was exactly what the difference was between those two. Typically a changelog is a central location to see the changes per release. This repository was missing that changelog. I took the liberty of creating one.

- Introduce `CHANGELOG.md`, populated with the releases starting with `1.0.0`. The format is based on [Keep a Changelog](https://keepachangelog.com) and the changelog from [psr/cache](https://github.com/php-fig/cache/blob/master/CHANGELOG.md).
