### PR TITLE
extend cache interface with throwable for v1.x.x

### DIFF
--- a/src/CacheException.php
+++ b/src/CacheException.php
@@ -5,6 +5,6 @@ namespace Psr\SimpleCache;
 /**
  * Interface used for all types of exceptions thrown by the implementing library.
  */
-interface CacheException
+interface CacheException extends \Throwable
 {
 }


### PR DESCRIPTION
Hello, can you please release this fix as 1.0.2?

This is a fix for PHP 7.4

Static analysators (PHPStan) returns error for `@throws` doc that `Psr\SimpleCache\InvalidArgumentException is not subtype of Throwable`

This issue is already fixed in v2 and v3, but they are also using union types, which breaks PHP 7.4

(unfortunately updating project to 8.0+ is not under my control)
