### PR TITLE
Removes the requirement to throw `InvalidArgumentException` when a parameter "is neither an array nor a Traversable"

### DIFF
--- a/src/CacheInterface.php
+++ b/src/CacheInterface.php
@@ -61,8 +61,7 @@ interface CacheInterface
      * @return iterable<string, mixed> A list of key => value pairs. Cache keys that do not exist or are stale will have $default as value.
      *
      * @throws \Psr\SimpleCache\InvalidArgumentException
-     *   MUST be thrown if $keys is neither an array nor a Traversable,
-     *   or if any of the $keys are not a legal value.
+     *   MUST be thrown if any of the $keys are not a legal value.
      */
     public function getMultiple(iterable $keys, mixed $default = null): iterable;
 
@@ -77,8 +76,7 @@ interface CacheInterface
      * @return bool True on success and false on failure.
      *
      * @throws \Psr\SimpleCache\InvalidArgumentException
-     *   MUST be thrown if $values is neither an array nor a Traversable,
-     *   or if any of the $values are not a legal value.
+     *   MUST be thrown if any of the $values are not a legal value.
      */
     public function setMultiple(iterable $values, null|int|\DateInterval $ttl = null): bool;
 
@@ -90,8 +88,7 @@ interface CacheInterface
      * @return bool True if the items were successfully removed. False if there was an error.
      *
      * @throws \Psr\SimpleCache\InvalidArgumentException
-     *   MUST be thrown if $keys is neither an array nor a Traversable,
-     *   or if any of the $keys are not a legal value.
+     *   MUST be thrown if any of the $keys are not a legal value.
      */
     public function deleteMultiple(iterable $keys): bool;
 


### PR DESCRIPTION
Removes the requirement to throw `\Psr\SimpleCache\InvalidArgumentException` when a parameter "is neither an array nor a Traversable". With the `iterable` definition on the parameter, ~it is functionally *impossible* to do so~. 

PHP will natively throw a `TypeError` before the implementation is given any chance to throw its own exception.

I might be splitting hairs here, but I believe the current docs were leftover from before the parameters were defined as `iterable` and it makes sense to remove a `MUST` for something that is literally impossible with the current interface definition.